### PR TITLE
Add more options for blocks that ropes can extend into

### DIFF
--- a/extendingladder.lua
+++ b/extendingladder.lua
@@ -11,9 +11,9 @@ local wood_recipe = {
 local wood_name = S("Wooden Extendable Ladder")
 
 local steel_recipe = {
-		{"default:steel_ingot", "", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
 		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"default:steel_ingot", "", "default:steel_ingot"},
 	}
 local steel_name = S("Steel Extendable Ladder")
 

--- a/extendingladder.lua
+++ b/extendingladder.lua
@@ -11,9 +11,9 @@ local wood_recipe = {
 local wood_name = S("Wooden Extendable Ladder")
 
 local steel_recipe = {
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"default:steel_ingot", "", "default:steel_ingot"},
 		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
 	}
 local steel_name = S("Steel Extendable Ladder")
 

--- a/functions.lua
+++ b/functions.lua
@@ -9,16 +9,19 @@ ropes.make_rope_on_timer = function(rope_node_name)
 		local oldnode = minetest.get_node(pos)
 		if currentlength > 1 and (not minetest.is_protected(newpos, placer_name)
 		or minetest.check_player_privs(placer_name, "protection_bypass")) then
-			if  newnode.name == "air" then
-				minetest.add_node(newpos, {name=currentend.name, param2=oldnode.param2})
-				local newmeta = minetest.get_meta(newpos)
-				newmeta:set_int("length_remaining", currentlength-1)
-				newmeta:set_string("placer", placer_name)
-				minetest.set_node(pos, {name=rope_node_name, param2=oldnode.param2})
-				ropes.move_players_down(pos, 1)
-			else
-				local timer = minetest.get_node_timer( pos )
-				timer:start( 1 )
+			for _, node_extend in pairs(ropes.rope_extends_into_nodes) do
+				if  newnode.name == node_extend then
+					minetest.add_node(newpos, {name=currentend.name, param2=oldnode.param2})
+					local newmeta = minetest.get_meta(newpos)
+					newmeta:set_int("length_remaining", currentlength-1)
+					newmeta:set_string("placer", placer_name)
+					minetest.set_node(pos, {name=rope_node_name, param2=oldnode.param2})
+					ropes.move_players_down(pos, 1)
+					break
+				else
+					local timer = minetest.get_node_timer( pos )
+					timer:start( 1 )
+				end
 			end
 		end
 	end

--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,12 @@ if ropes.bridges_enabled == nil then
 	ropes.bridges_enabled = true
 end
 
+ropes.rope_extends_into_nodes = { "air" }
+
+if minetest.get_modpath("nether") then
+   table.insert(ropes.rope_extends_into_nodes, "nether:fumes")
+end
+
 dofile( MP .. "/doc.lua" )
 dofile( MP .. "/functions.lua" )
 dofile( MP .. "/crafts.lua" )

--- a/ropeboxes.lua
+++ b/ropeboxes.lua
@@ -155,11 +155,14 @@ local function register_rope_block(multiple, max_multiple, name_prefix, node_pre
 			end
 		
 			local node_below = minetest.get_node(pos_below)
-			if node_below.name == "air" then
-				minetest.add_node(pos_below, {name="ropes:rope_bottom"})
-				local meta = minetest.get_meta(pos_below)
-				meta:set_int("length_remaining", ropes.ropeLength*multiple)
-				meta:set_string("placer", placer:get_player_name())
+			for _, node_extend in pairs(ropes.rope_extends_into_nodes) do
+				if node_below.name == node_extend then
+					minetest.add_node(pos_below, {name="ropes:rope_bottom"})
+					local meta = minetest.get_meta(pos_below)
+					meta:set_int("length_remaining", ropes.ropeLength*multiple)
+					meta:set_string("placer", placer:get_player_name())
+					break
+				end
 			end
 		end,
 		


### PR DESCRIPTION
Ropes currently work only on extending into the "air" node, preventing ropeboxes from working in any environment that has a non-air atmosphere. This allows adding arbitrary nodes, including conditional on the presence of a given mod, that ropeboxes should be able to work in - included is an example with nether:fumes from [BlockySurvival/nether](https://github.com/BlockySurvival/nether/blob/master/nodes.lua).