### PR TITLE
fix recipe for steel extendable ladder (conflicts with 3d_armor)

### DIFF
--- a/extendingladder.lua
+++ b/extendingladder.lua
@@ -11,9 +11,9 @@ local wood_recipe = {
 local wood_name = S("Wooden Extendable Ladder")
 
 local steel_recipe = {
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"default:steel_ingot", "", "default:steel_ingot"},
 		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
-		{"default:steel_ingot", "", "default:steel_ingot"},
 	}
 local steel_name = S("Steel Extendable Ladder")
 


### PR DESCRIPTION
`ropes:ladder_steel` has the same recipe as `3d_armor:leggings_steel`. This should fix the recipe conflict.