### PR TITLE
Update mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
 name = ropes
+description = Adds rope boxes and ladders
+depends = default
+optional_depends = cottages, doc, farming, hemp, intllib, loot, vines


### PR DESCRIPTION
I noticed that without adding it to `optional_depends` in mod.conf, the vines mod sometimes loads after ropes on my server and thus overwrites the aliases definied here:
https://github.com/minetest-mods/ropes/blob/master/init.lua#L46-L57

Probably the same goes for other depends, it seems like depends.txt is ignored if a mod.conf is found.
Should depends.txt be removed completely to avoid confusion?