### PR TITLE
Use MT5 builtin’s translation system

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -2,7 +2,6 @@ default
 farming?
 vines?
 doc?
-intllib?
 loot?
 hemp?
 cottages?


### PR DESCRIPTION
Remove `intllib` optional dependency.