### PR TITLE
Add attached_node to rope boxes.

### DIFF
--- a/ropeboxes.lua
+++ b/ropeboxes.lua
@@ -132,7 +132,7 @@ local function register_rope_block(multiple, max_multiple, name_prefix, node_pre
 		},
 		selection_box = {type="regular"},
 		collision_box = {type="regular"},
-		groups = {choppy=2, oddly_breakable_by_hand=1, rope_block = 1},
+		groups = {attached_node = 1, choppy=2, oddly_breakable_by_hand=1, rope_block = 1},
 		
 		on_place = function(itemstack, placer, pointed_thing)
 			if pointed_thing.type == "node" then


### PR DESCRIPTION
Floating rope boxes look weird so lets fix that.