### PR TITLE
modify wood ladder recipe

### DIFF
--- a/extendingladder.lua
+++ b/extendingladder.lua
@@ -3,9 +3,9 @@ local S = ropes.S
 if ropes.extending_ladder_enabled then
 
 local wood_recipe = {
+		{"group:stick", "", "group:stick"},
+		{"group:stick", "", "group:stick"},
 		{"group:stick", "group:stick", "group:stick"},
-		{"group:stick", "", "group:stick"},
-		{"group:stick", "", "group:stick"},
 	}
 local wood_name = S("Wooden Extendable Ladder")
 


### PR DESCRIPTION
1. same recipe schema like steel ladder
2. Fixes that `homedecor:table_legs_wood` and `ropes:ladder_wood` have the same recipes