### PR TITLE
Add crafting support for farming redo and moreblocks

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -17,6 +17,16 @@ if minetest.get_modpath("farming") then
 			{'farming:cotton','farming:cotton'},
 		}
 	})
+
+	if farming.mod == "redo" or farming.mod == "undo" then
+		minetest.register_craft({
+			output = 'ropes:ropesegment',
+			recipe = {
+				{'farming:hemp_rope'},
+				{'farming:hemp_rope'},
+			}
+		})
+	end
 end
 
 if minetest.get_modpath("hemp") then
@@ -35,6 +45,17 @@ if minetest.get_modpath("cottages") then
 		recipe = {
 			{'cottages:rope'},
 			{'cottages:rope'},
+		}
+	})
+end
+
+if minetest.get_modpath("moreblocks") then
+	minetest.register_craft({
+		output = 'ropes:ropesegment',
+		recipe = {
+			{'moreblocks:rope','moreblocks:rope'},
+			{'moreblocks:rope','moreblocks:rope'},
+			{'moreblocks:rope','moreblocks:rope'},
 		}
 	})
 end


### PR DESCRIPTION
This PR adds recipes to support ropes from Farming Redo and Moreblocks.

This PR is ready for review.