### PR TITLE
Allow swapping between default and ropes ladder by crafting

### DIFF
--- a/extendingladder.lua
+++ b/extendingladder.lua
@@ -67,6 +67,19 @@ steel_name = S("Steel Ladder")
 
 texture_overlay = ""
 
+else
+	-- Swap between normal and extendable ladders
+	minetest.register_craft({
+		type = "shapeless",
+		output = "ropes:ladder_wood",
+		recipe = {"default:ladder_wood"},
+	})
+
+	minetest.register_craft({
+		type = "shapeless",
+		output = "ropes:ladder_steel",
+		recipe = {"default:ladder_steel"},
+	})
 end
 
 minetest.register_craft({


### PR DESCRIPTION
This PR adds recipes for players to swap their ladders between normal and extendable variants if one is not replacing another.

This PR is ready for review.